### PR TITLE
Update redirect rule after the end of the game / -> /about

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,13 +1,15 @@
 # Redirect URLs (FROM, TO, 301!)
 /register /app 301!
 /competition /app 301!
-/ /app 301!
+
+# Gravity-DEX endpoint after the end of the competition
+/ /about 301!
 
 # Redirect URLs to external websites 301!
 /legal https://gravitydex.io/terms-and-conditions.pdf
 /terms https://gravitydex.io/terms-and-conditions.pdf
 
-# Gravidy-DEX endpoint
+# Gravity-DEX endpoint
 /app/* https://d2acv4xwjreiuz.cloudfront.net/:splat 200
 /app https://d2acv4xwjreiuz.cloudfront.net 200
 /static/* https://d2acv4xwjreiuz.cloudfront.net/static/:splat 200


### PR DESCRIPTION
Hi @lovincyrus, When the competition ends on `Mon May 11 00:00 UTC 2021` (after 8 hours roughly from now), I would like to re-direct the `/` to the `/about` page. 

Could you please merge and deploy just in time above(`Mon May 11 00:00 UTC 2021`)?
Let me know if there's anything wrong with redirection or if there's a better way.

On the app page, we are planning to leave only the rank page so that they can check the rank after the competition.